### PR TITLE
Add client-side order notifications

### DIFF
--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -3,6 +3,53 @@ AddEventHandler('way:orderCreated', function(data)
     print('Order created: ' .. data.id)
 end)
 
+-- Incoming order/notification events ---------------------------------------
+RegisterNetEvent('way:newOrder')
+AddEventHandler('way:newOrder', function(data)
+    TriggerEvent('lb-phone:notify', {
+        title = 'Way Delivery',
+        message = 'Nueva orden #' .. data.id,
+        icon = 'fas fa-hamburger',
+        duration = 5000
+    })
+    SendNUIMessage('refreshBusinessOrders')
+end)
+
+RegisterNetEvent('way:orderAccepted')
+AddEventHandler('way:orderAccepted', function(id)
+    TriggerEvent('lb-phone:notify', {
+        title = 'Way Delivery',
+        message = 'Orden #' .. id .. ' aceptada',
+        icon = 'fas fa-hamburger',
+        duration = 5000
+    })
+    SendNUIMessage('refreshBusinessOrders')
+end)
+
+RegisterNetEvent('way:orderReady')
+AddEventHandler('way:orderReady', function(id)
+    TriggerEvent('lb-phone:notify', {
+        title = 'Way Delivery',
+        message = 'Orden #' .. id .. ' lista para delivery',
+        icon = 'fas fa-hamburger',
+        duration = 5000
+    })
+    SendNUIMessage('refreshBusinessOrders')
+    SendNUIMessage('refreshDeliveryOrders')
+end)
+
+RegisterNetEvent('way:orderTaken')
+AddEventHandler('way:orderTaken', function(id)
+    TriggerEvent('lb-phone:notify', {
+        title = 'Way Delivery',
+        message = 'Orden #' .. id .. ' recogida',
+        icon = 'fas fa-hamburger',
+        duration = 5000
+    })
+    SendNUIMessage('refreshBusinessOrders')
+    SendNUIMessage('refreshDeliveryOrders')
+end)
+
 -- Send messages to UI
 local function openUI()
     SetNuiFocus(true, true)

--- a/resource/ui/script.js
+++ b/resource/ui/script.js
@@ -163,6 +163,10 @@ window.addEventListener('message', (e) => {
     loadDeliveryOrders();
   } else if (e.data === 'close') {
     document.getElementById('app').style.display = 'none';
+  } else if (e.data === 'refreshBusinessOrders') {
+    loadBusinessOrders();
+  } else if (e.data === 'refreshDeliveryOrders') {
+    loadDeliveryOrders();
   }
 });
 


### PR DESCRIPTION
## Summary
- handle new order events on the client
- refresh UI sections from the phone app

## Testing
- `node --check resource/ui/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6875b27eda2c83288c71823b20cf3373