### PR TITLE
Add order rejection event

### DIFF
--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -66,6 +66,11 @@ RegisterNUICallback('acceptOrder', function(data, cb)
     cb({})
 end)
 
+RegisterNUICallback('rejectOrder', function(data, cb)
+    TriggerServerEvent('way:rejectOrder', data.id)
+    cb({})
+end)
+
 RegisterNUICallback('readyOrder', function(data, cb)
     TriggerServerEvent('way:readyOrder', data.id)
     cb({})

--- a/resource/server/main.lua
+++ b/resource/server/main.lua
@@ -113,6 +113,27 @@ RegisterNetEvent('way:acceptOrder', function(id)
     end)
 end)
 
+-- Business rejects order
+RegisterNetEvent('way:rejectOrder', function(id)
+    local src = source
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return end
+    MySQL.single('SELECT negocio_id, user_id FROM wayya WHERE id=? AND record_type="order"', {id}, function(order)
+        if not order then return end
+        MySQL.single('SELECT id FROM wayya WHERE id=? AND dueno_id=? AND record_type="business"', {order.negocio_id, xPlayer.identifier}, function(b)
+            if not b then
+                notify(src, 'Way Delivery', 'No tienes permiso para esa orden')
+                return
+            end
+            MySQL.update('UPDATE wayya SET estado="rechazado" WHERE id=? AND record_type="order"', {id})
+            local customer = ESX.GetPlayerFromIdentifier(order.user_id)
+            if customer then
+                notify(customer.source, 'Way Delivery', 'Tu pedido #'..id..' fue rechazado')
+            end
+        end)
+    end)
+end)
+
 -- Order ready for delivery
 RegisterNetEvent('way:readyOrder', function(id)
     local src = source

--- a/resource/ui/script.js
+++ b/resource/ui/script.js
@@ -116,6 +116,7 @@ function loadBusinessOrders() {
         <p>Orden #${o.id} - $${o.total}</p>
         <div class="mt-2 flex space-x-2">
           <button class="accept px-2 py-1 bg-green-600 rounded" data-id="${o.id}">Aceptar</button>
+          <button class="reject px-2 py-1 bg-red-600 rounded" data-id="${o.id}">Rechazar</button>
           <button class="ready px-2 py-1 bg-yellow-600 rounded" data-id="${o.id}">Enviar a delivery</button>
         </div>`;
       container.appendChild(div);
@@ -127,6 +128,9 @@ document.getElementById('businessOrders').addEventListener('click', (e) => {
   const id = e.target.dataset.id;
   if (e.target.classList.contains('accept')) {
     nui('acceptOrder', { id }).then(loadBusinessOrders);
+  }
+  if (e.target.classList.contains('reject')) {
+    nui('rejectOrder', { id }).then(loadBusinessOrders);
   }
   if (e.target.classList.contains('ready')) {
     nui('readyOrder', { id }).then(loadBusinessOrders);


### PR DESCRIPTION
## Summary
- add `way:rejectOrder` server event to update status and notify customer
- expose new `rejectOrder` NUI callback in client
- provide Reject button in business view UI

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6875b286a9fc8328b0227761a8eea12f