### PR TITLE
Add my orders NUI callback and UI

### DIFF
--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -77,6 +77,12 @@ RegisterNUICallback('getAvailableOrders', function(data, cb)
     end)
 end)
 
+RegisterNUICallback('getMyOrders', function(data, cb)
+    ESX.TriggerServerCallback('way:getMyOrders', function(res)
+        cb(res)
+    end)
+end)
+
 RegisterNUICallback('takeOrder', function(data, cb)
     TriggerServerEvent('way:takeOrder', data.id)
     cb({})

--- a/resource/server/main.lua
+++ b/resource/server/main.lua
@@ -79,6 +79,14 @@ ESX.RegisterServerCallback('way:getAvailableOrders', function(source, cb)
     end)
 end)
 
+ESX.RegisterServerCallback('way:getMyOrders', function(source, cb)
+    local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer then return cb({}) end
+    MySQL.query('SELECT id, total, estado FROM wayya WHERE record_type="order" AND user_id=? ORDER BY created_at DESC', {xPlayer.identifier}, function(res)
+        cb(res or {})
+    end)
+end)
+
 -- Client creates an order
 RegisterNetEvent('way:createOrder', function(data)
     local src = source

--- a/resource/ui/index.html
+++ b/resource/ui/index.html
@@ -20,6 +20,7 @@
         <div id="businessList" class="space-y-2"></div>
         <div id="menu" class="hidden"></div>
         <div id="cart" class="hidden mt-4"></div>
+        <div id="myOrders" class="mt-4 space-y-2"></div>
       </div>
 
       <div id="business" class="tab-content hidden">

--- a/resource/ui/script.js
+++ b/resource/ui/script.js
@@ -29,6 +29,26 @@ async function nui(action, data) {
 let currentBusiness = null;
 let cart = [];
 
+function loadMyOrders() {
+  nui('getMyOrders').then((orders) => {
+    const container = document.getElementById('myOrders');
+    container.innerHTML = '<h2 class="font-bold mb-2">Mis pedidos</h2>';
+    (orders || []).forEach((o) => {
+      const div = document.createElement('div');
+      div.className = 'bg-gray-800 p-2 rounded mt-1 flex justify-between items-center';
+      div.innerHTML = `<span>Orden #${o.id} - $${o.total} (${o.estado})</span>`;
+      if (o.estado !== 'entregado') {
+        const btn = document.createElement('button');
+        btn.className = 'pay px-2 py-1 bg-green-600 rounded';
+        btn.dataset.id = o.id;
+        btn.textContent = 'Pagar';
+        div.appendChild(btn);
+      }
+      container.appendChild(div);
+    });
+  });
+}
+
 function loadBusinesses() {
   nui('getBusinesses').then((list) => {
     if (!Array.isArray(list)) return;
@@ -133,6 +153,13 @@ document.getElementById('businessOrders').addEventListener('click', (e) => {
   }
 });
 
+document.getElementById('myOrders').addEventListener('click', (e) => {
+  if (e.target.classList.contains('pay')) {
+    const id = e.target.dataset.id;
+    nui('payOrder', { id }).then(loadMyOrders);
+  }
+});
+
 // DELIVERY VIEW ------------------------------------------------------------
 function loadDeliveryOrders() {
   nui('getAvailableOrders').then((orders) => {
@@ -160,6 +187,7 @@ window.addEventListener('message', (e) => {
     document.getElementById('app').style.display = 'block';
     loadBusinesses();
     loadBusinessOrders();
+    loadMyOrders();
     loadDeliveryOrders();
   } else if (e.data === 'close') {
     document.getElementById('app').style.display = 'none';
@@ -170,6 +198,7 @@ window.addEventListener('message', (e) => {
 document.addEventListener('DOMContentLoaded', () => {
   loadBusinesses();
   loadBusinessOrders();
+  loadMyOrders();
   loadDeliveryOrders();
 });
 


### PR DESCRIPTION
## Summary
- add `getMyOrders` NUI callback client-side
- implement server-side ESX callback querying player orders
- display a new "Mis pedidos" section under the client tab
- show orders with optional **Pagar** button and handle payment from UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875b2870e5c8328908b9a452d5c005b