### PR TITLE
Add category filter for businesses

### DIFF
--- a/docs/wayya.sql
+++ b/docs/wayya.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS wayya (
 
     -- Datos del negocio
     nombre VARCHAR(50) NULL,
+    categoria VARCHAR(50) NULL,
     menu LONGTEXT NULL,
     dueno_id VARCHAR(60) NULL,
     ubicacion_negocio LONGTEXT NULL,

--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -43,7 +43,7 @@ end)
 RegisterNUICallback('getBusinesses', function(data, cb)
     ESX.TriggerServerCallback('way:getBusinesses', function(res)
         cb(res)
-    end)
+    end, data.categoria)
 end)
 
 RegisterNUICallback('getBusinessMenu', function(data, cb)

--- a/resource/server/main.lua
+++ b/resource/server/main.lua
@@ -10,6 +10,7 @@ MySQL.ready(function()
         id INT AUTO_INCREMENT PRIMARY KEY,
         record_type ENUM('business','order','delivery_job') NOT NULL,
         nombre VARCHAR(50) NULL,
+        categoria VARCHAR(50) NULL,
         menu LONGTEXT NULL,
         dueno_id VARCHAR(60) NULL,
         ubicacion_negocio LONGTEXT NULL,
@@ -36,8 +37,14 @@ local function notify(src, title, msg)
 end
 
 -- Client requests list of businesses
-ESX.RegisterServerCallback('way:getBusinesses', function(source, cb)
-    MySQL.query('SELECT id, nombre, menu FROM wayya WHERE record_type="business"', {}, function(res)
+ESX.RegisterServerCallback('way:getBusinesses', function(source, cb, categoria)
+    local query = 'SELECT id, nombre, categoria FROM wayya WHERE record_type="business"'
+    local params = {}
+    if categoria and categoria ~= '' then
+        query = query .. ' AND categoria=?'
+        params = {categoria}
+    end
+    MySQL.query(query, params, function(res)
         cb(res)
     end)
 end)

--- a/resource/ui/index.html
+++ b/resource/ui/index.html
@@ -17,6 +17,7 @@
       </div>
 
       <div id="client" class="tab-content">
+        <select id="categoryFilter" class="mb-2 bg-gray-800 p-1 rounded"></select>
         <div id="businessList" class="space-y-2"></div>
         <div id="menu" class="hidden"></div>
         <div id="cart" class="hidden mt-4"></div>

--- a/resource/ui/script.js
+++ b/resource/ui/script.js
@@ -28,10 +28,25 @@ async function nui(action, data) {
 // CLIENT VIEW --------------------------------------------------------------
 let currentBusiness = null;
 let cart = [];
+let currentCategory = '';
 
-function loadBusinesses() {
-  nui('getBusinesses').then((list) => {
+function populateCategories(list) {
+  const sel = document.getElementById('categoryFilter');
+  sel.innerHTML = '<option value="">Todas</option>';
+  const cats = [...new Set(list.map((b) => b.categoria).filter(Boolean))];
+  cats.forEach((c) => {
+    const opt = document.createElement('option');
+    opt.value = c;
+    opt.textContent = c;
+    sel.appendChild(opt);
+  });
+}
+
+function loadBusinesses(category) {
+  if (category !== undefined) currentCategory = category;
+  nui('getBusinesses', { categoria: currentCategory }).then((list) => {
     if (!Array.isArray(list)) return;
+    if (!currentCategory) populateCategories(list);
     const container = document.getElementById('businessList');
     container.innerHTML = '';
     list.forEach((b) => {
@@ -51,6 +66,10 @@ document.getElementById('businessList').addEventListener('click', (e) => {
       showMenu(menu || []);
     });
   }
+});
+
+document.getElementById('categoryFilter').addEventListener('change', (e) => {
+  loadBusinesses(e.target.value);
 });
 
 function showMenu(menu) {
@@ -158,7 +177,7 @@ document.getElementById('deliveryOrders').addEventListener('click', (e) => {
 window.addEventListener('message', (e) => {
   if (e.data === 'open') {
     document.getElementById('app').style.display = 'block';
-    loadBusinesses();
+    loadBusinesses('');
     loadBusinessOrders();
     loadDeliveryOrders();
   } else if (e.data === 'close') {
@@ -168,7 +187,7 @@ window.addEventListener('message', (e) => {
 
 // For local testing without phone
 document.addEventListener('DOMContentLoaded', () => {
-  loadBusinesses();
+  loadBusinesses('');
   loadBusinessOrders();
   loadDeliveryOrders();
 });


### PR DESCRIPTION
## Summary
- add `categoria` column to schema and table creation
- return and filter by `categoria` in server callback
- pass category parameter from NUI
- add category dropdown in UI and fetch businesses filtered by category

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875b288c9bc832894e593632aefcdf8