### PR TITLE
Add notifications for new orders

### DIFF
--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -3,6 +3,21 @@ AddEventHandler('way:orderCreated', function(data)
     print('Order created: ' .. data.id)
 end)
 
+-- When a new order is created notify the player and refresh the UI
+RegisterNetEvent('way:newOrder')
+AddEventHandler('way:newOrder', function(data)
+    -- Show phone notification
+    TriggerEvent('lb-phone:notify', {
+        title = 'Way Delivery',
+        message = 'Nueva orden #' .. tostring(data.id),
+        icon = 'fas fa-hamburger',
+        duration = 5000
+    })
+
+    -- Update business orders list if UI is open
+    SendNUIMessage('refreshBusinessOrders')
+end)
+
 -- Send messages to UI
 local function openUI()
     SetNuiFocus(true, true)

--- a/resource/ui/script.js
+++ b/resource/ui/script.js
@@ -163,6 +163,8 @@ window.addEventListener('message', (e) => {
     loadDeliveryOrders();
   } else if (e.data === 'close') {
     document.getElementById('app').style.display = 'none';
+  } else if (e.data === 'refreshBusinessOrders') {
+    loadBusinessOrders();
   }
 });
 


### PR DESCRIPTION
## Summary
- handle `way:newOrder` on the client
- show lb-phone notification for incoming orders
- refresh the business order list in the UI when a new order arrives

## Testing
- `node --check resource/ui/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6875b289c0b4832892b2babfede9009b