### PR TITLE
Fix stray end in main.lua

### DIFF
--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -188,6 +188,3 @@ AddEventHandler('way:orderLocations', function(data)
     -- store for optional use by other scripts
     CurrentDeliveryLocations = data
 end)
-
-end)
-


### PR DESCRIPTION
## Summary
- fix stray extra end after `way:orderLocations` event handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875bbecb0f483289c04ae5f1685f0b7